### PR TITLE
Add Terraform to create a DigitalOcean managed database, Update for ArgoCD

### DIFF
--- a/infrastructure/terraform/bootstrapper.tfvars.sample
+++ b/infrastructure/terraform/bootstrapper.tfvars.sample
@@ -33,6 +33,10 @@ doks_additional_node_pools = {
 # Set the flag to 'true' to enable DOCR
 enable_container_registry        = false
 
+# =============================== DIGITALOCEAN DATABASES =================================
+# Set the flag to 'true' to enable Databases
+enable_databases                 = false
+
 # ================================== ARGOCD CONFIG ==================================
 
 # ArgoCD Helm release is disabled for now because it is not working properly in Terraform

--- a/infrastructure/terraform/bootstrapper.tfvars.sample
+++ b/infrastructure/terraform/bootstrapper.tfvars.sample
@@ -38,8 +38,6 @@ enable_container_registry        = false
 enable_databases                 = false
 
 # ================================== ARGOCD CONFIG ==================================
-
-# ArgoCD Helm release is disabled for now because it is not working properly in Terraform
 enable_argocd_helm_release        = true
 argocd_helm_repo                  = "https://argoproj.github.io/argo-helm"
 argocd_helm_chart                 = "argo-cd"

--- a/infrastructure/terraform/digitalocean-databases.tf
+++ b/infrastructure/terraform/digitalocean-databases.tf
@@ -1,0 +1,16 @@
+
+locals {
+  database_cluster_name = "${var.database_cluster_name_prefix}-${var.database_cluster_engine}-${var.database_cluster_region}-${random_id.cluster_name.hex}"
+}
+
+# https://docs.digitalocean.com/reference/terraform/reference/resources/database_cluster/
+# It creates a default database called defaultdb and a default user called doadmin
+resource "digitalocean_database_cluster" "bootstrapper" {
+    count      = var.enable_databases ? 1 : 0
+    name       = local.database_cluster_name
+    engine     = var.database_cluster_engine
+    version    = var.database_cluster_version
+    region     = var.database_cluster_region
+    size       = var.database_cluster_size
+    node_count = var.database_cluster_node_count
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -42,9 +42,9 @@ output "database_password" {
 
 # ================================== ARGOCD ==================================
 output "argocd_helm_chart_values" {
-  value = helm_release.argocd[0].values
+  value = var.enable_argocd_helm_release ? helm_release.argocd[0].values : null
 }
 
 output "argocd_helm_chart_manifest" {
-  value = helm_release.argocd[0].manifest
+  value = var.enable_argocd_helm_release ? helm_release.argocd[0].manifest : null
 }

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -8,6 +8,11 @@ output "cluster_name" {
 }
 
 # ======================= DIGITALOCEAN DATABASES =========================
+output "database_id" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].id : null
+  description = "Database ID"
+}
+
 output "database_uri" {
   value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].uri : null
   description = "Database URI"

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,3 +1,4 @@
+# ============================== DOKS ==============================
 output "cluster_id" {
   value = digitalocean_kubernetes_cluster.bootstrapper.id
 }
@@ -6,6 +7,40 @@ output "cluster_name" {
   value = digitalocean_kubernetes_cluster.bootstrapper.name
 }
 
+# ======================= DIGITALOCEAN DATABASES =========================
+output "database_uri" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].uri : null
+  description = "Database URI"
+  sensitive = true
+}
+
+output "database_host" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].host : null
+  description = "Database host"
+}
+
+output "database_port" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].port : null
+  description = "Database port"
+}
+
+output "database_name" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].database : null
+  description = "Database name"
+}
+
+output "database_user" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].user : null
+  description = "Database user"
+}
+
+output "database_password" {
+  value = var.enable_databases ? digitalocean_database_cluster.bootstrapper[0].password : null
+  description = "Database password"
+  sensitive = true
+}
+
+# ================================== ARGOCD ==================================
 output "argocd_helm_chart_values" {
   value = helm_release.argocd[0].values
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -62,6 +62,50 @@ variable "enable_container_registry" {
   description = "Enable/disable DigitalOcean Container Registry"
 }
 
+# ===================== DigitalOcean Databases CONFIG VARS =======================
+variable "enable_databases" {
+  type        = bool
+  default     = false
+  description = "Enable/disable DigitalOcean Databases"
+}
+
+# DigitalOcean Database Cluster
+variable "database_cluster_name_prefix" {
+  type        = string
+  default     = "bootstrapper-db"
+  description = "DigitalOcean Databases cluster name"
+}
+
+variable "database_cluster_engine" {
+  type        = string
+  default     = "pg" #postgres
+  description = "DigitalOcean Databases cluster engine"
+}
+
+variable "database_cluster_size" {
+  type        = string
+  default     = "db-s-1vcpu-1gb"
+  description = "DigitalOcean Databases cluster size"
+}
+
+variable "database_cluster_region" {
+  type        = string
+  default     = "nyc3"
+  description = "DigitalOcean Databases cluster region"
+}
+
+variable "database_cluster_version" {
+  type        = string
+  default     = "16"
+  description = "DigitalOcean Databases cluster version"
+}
+
+variable "database_cluster_node_count" {
+  type        = number
+  default     = 1
+  description = "DigitalOcean Databases cluster node count"
+}
+
 # ===================== ARGOCD HELM CONFIG VARS =======================
 
 variable "enable_argocd_helm_release" {


### PR DESCRIPTION
I added Terraform to create a database cluster with a default database. The defaults are for PostgreSQL. 

A future update can be to add making a database and/or user. Also to update the README to tell the user if they want to see the password and URI that they need to change the output to have sensitive=false. But for now just add this since it works.

Made fixes for #24 (the force push was just adding the issue # to the commit)

@diabhey 